### PR TITLE
Reject the ZIP file and report it as corrupt if the size of the

### DIFF
--- a/bins/unzzipcat-zip.c
+++ b/bins/unzzipcat-zip.c
@@ -78,7 +78,7 @@ static int unzzip_cat (int argc, char ** argv, int extract)
     
     disk = zzip_dir_open (argv[1], &error);
     if (! disk) {
-	perror(argv[1]);
+	fprintf(stderr, "%s: %s\n", argv[1], zzip_strerror(error));
 	return -1;
     }
 

--- a/zzip/zip.c
+++ b/zzip/zip.c
@@ -320,6 +320,12 @@ __zzip_fetch_disk_trailer(int fd, zzip_off_t filesize,
 #                  endif
 
                     __fixup_rootseek(offset + tail - mapped, trailer);
+		    /*
+		     * "extract data from files archived in a single zip file."
+		     * So the file offsets must be within the current ZIP archive!
+		     */
+		    if (trailer->zz_rootseek >= filesize || (trailer->zz_rootseek + trailer->zz_rootsize) >= filesize)
+		        return(ZZIP_CORRUPTED);
                     { return(0); }
                 } else if ((*tail == 'P') &&
                            end - tail >=
@@ -338,6 +344,12 @@ __zzip_fetch_disk_trailer(int fd, zzip_off_t filesize,
                         zzip_disk64_trailer_finalentries(orig);
                     trailer->zz_rootseek = zzip_disk64_trailer_rootseek(orig);
                     trailer->zz_rootsize = zzip_disk64_trailer_rootsize(orig);
+		    /*
+		     * "extract data from files archived in a single zip file."
+		     * So the file offsets must be within the current ZIP archive!
+		     */
+		    if (trailer->zz_rootseek >= filesize || (trailer->zz_rootseek + trailer->zz_rootsize) >= filesize)
+		        return(ZZIP_CORRUPTED);
                     { return(0); }
 #                  endif
                 }


### PR DESCRIPTION
central directory and/or the offset of start of central directory
point beyond the end of the ZIP file. [CVE-2018-6484]