### PR TITLE
Make sure an extension block is large enough.

### DIFF
--- a/zzip/memdisk.c
+++ b/zzip/memdisk.c
@@ -306,7 +306,14 @@ zzip_mem_entry_find_extra_block(ZZIP_MEM_ENTRY * entry, short datatype, zzip_siz
         char* ext_end = ext + entry->zz_extlen[i];
         if (ext)
         {
-            while (ext + zzip_extra_block_headerlength <= ext_end)
+	    /*
+	     * Make sure that
+	     * 1) the extra block header
+	     * AND
+	     * 2) the block we're looking for
+	     * fit into the extra block!
+	     */
+            while (ext + zzip_extra_block_headerlength + blocksize <= ext_end)
             {
                 if (datatype == zzip_extra_block_get_datatype(ext))
                 {

--- a/zzip/mmapped.c
+++ b/zzip/mmapped.c
@@ -458,6 +458,12 @@ zzip_disk_findfirst(ZZIP_DISK * disk)
             errno = EBADMSG;
             return 0;
         }
+	if (root >= disk->endbuf)
+	{
+	    DBG1("root behind endbuf should be impossible");
+	    errno = EBADMSG;
+	    return 0;
+	}
         if (zzip_disk_entry_check_magic(root))
         {
             DBG1("found the disk root");


### PR DESCRIPTION
- If an extension block is too small to hold an extension,
  do not use the information therein.
- If the End of central directory record (EOCD) contains an
  Offset of start of central directory which is beyond the end of
  the file, reject the file.
  [CVE-2018-6540]