### PR TITLE
Fixed a few bugs in zzip/mmapped.c, bins/unzzipcat-mem.c, zzip/memdisk.c

### DIFF
--- a/bins/unzzipcat-mem.c
+++ b/bins/unzzipcat-mem.c
@@ -59,7 +59,7 @@ static void makedirs(const char* name)
           makedirs(dir_name);
           free (dir_name);
       } else {
-          _zzip_mkdir(name, 775);
+          _zzip_mkdir(name, 0775);
           errno = 0;
       }
 }
@@ -104,8 +104,11 @@ static int unzzip_cat (int argc, char ** argv, int extract)
 	    char* name = zzip_mem_entry_to_name (entry);
 	    FILE* out = stdout;
 	    if (extract) out = create_fopen(name, "w", 1);
-	    unzzip_mem_disk_cat_file (disk, name, out);
-	    if (extract) fclose(out);
+	    if (out != NULL)
+	    {
+		unzzip_mem_disk_cat_file (disk, name, out);
+		if (extract) fclose(out);
+	    }
 	}
 	return 0;
     }
@@ -132,8 +135,11 @@ static int unzzip_cat (int argc, char ** argv, int extract)
 	    {
 	        FILE* out = stdout;
 	        if (extract) out = create_fopen(name, "w", 1);
-		unzzip_mem_disk_cat_file (disk, name, out);
-		if (extract) fclose(out);
+		if (out != NULL)
+		{
+		    unzzip_mem_disk_cat_file (disk, name, out);
+		    if (extract) fclose(out);
+		}
 		break; /* match loop */
 	    }
 	}

--- a/zzip/memdisk.c
+++ b/zzip/memdisk.c
@@ -144,6 +144,7 @@ zzip_mem_disk_load(ZZIP_MEM_DISK * dir, ZZIP_DISK * disk)
         zzip_mem_disk_unload(dir);
     ___ long count = 0;
     ___ struct zzip_disk_entry *entry = zzip_disk_findfirst(disk);
+    if (!entry) goto error;
     for (; entry; entry = zzip_disk_findnext(disk, entry))
     {
         ZZIP_MEM_ENTRY *item = zzip_mem_entry_new(disk, entry);

--- a/zzip/mmapped.c
+++ b/zzip/mmapped.c
@@ -414,7 +414,7 @@ zzip_disk_findfirst(ZZIP_DISK * disk)
     for (; p >= disk->buffer; p--)
     {
         zzip_byte_t *root;      /* (struct zzip_disk_entry*) */
-        if (zzip_disk_trailer_check_magic(p))
+        if (zzip_disk_trailer_check_magic(p) && (p + sizeof(struct zzip_disk_trailer)) <= disk->endbuf)
         {
             struct zzip_disk_trailer *trailer = (struct zzip_disk_trailer *) p;
             zzip_size_t rootseek = zzip_disk_trailer_get_rootseek(trailer);
@@ -431,17 +431,17 @@ zzip_disk_findfirst(ZZIP_DISK * disk)
                  * central directory was written directly before the trailer:*/
                 root = p - rootsize;
             }
-        } else if (zzip_disk64_trailer_check_magic(p))
+        } else if (zzip_disk64_trailer_check_magic(p) && (p + sizeof(struct zzip_disk64_trailer)) <= disk->endbuf)
         {
             struct zzip_disk64_trailer *trailer =
                 (struct zzip_disk64_trailer *) p;
+            zzip_size_t rootseek = zzip_disk64_trailer_get_rootseek(trailer);
             if (sizeof(void *) < 8)
             {
                 DBG1("disk64 trailer in non-largefile part");
                 errno = EFBIG;
                 return 0;
             }
-            zzip_size_t rootseek = zzip_disk64_trailer_get_rootseek(trailer);
             DBG2("disk64 rootseek at %lli", (long long)rootseek);
             root = disk->buffer + rootseek;
             if (root > p)


### PR DESCRIPTION
* in zzip_disk_findfirst(), check that the trailers fit inside the ZIP file
* in makedirs(), use 0775 (octal) rather tha 775 (01407 aka r-----r-t)
* in unzzip_cat(), if an output file cannot be create_fopen'ed, don't fclose() it!
* in zzip_mem_disk_load(), if zzip_disk_findfirst() returns NULL, return an error.