### PR TITLE
provide a workaround for missing strnlen #25

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -52,6 +52,9 @@
 /* Define to 1 if you have the `strndup' function. */
 #undef HAVE_STRNDUP
 
+/* Define to 1 if you have the `strnlen' function. */
+#undef HAVE_STRNLEN
+
 /* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
    */
 #undef HAVE_SYS_DIR_H

--- a/configure
+++ b/configure
@@ -12907,7 +12907,7 @@ fi
 
 done
 
-for ac_func in strcasecmp strndup
+for ac_func in strcasecmp strnlen strndup
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_CHECK_HEADERS(stdint.h unistd.h windows.h winnt.h winbase.h sys/int_types.h)
 AC_CHECK_HEADERS(sys/types.h sys/mman.h sys/stat.h sys/param.h) dnl posix'ish
 AC_CHECK_HEADERS(io.h direct.h zlib.h byteswap.h)
 AC_CHECK_HEADERS(fnmatch.h)
-AC_CHECK_FUNCS( strcasecmp strndup )
+AC_CHECK_FUNCS( strcasecmp strnlen strndup )
 
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T

--- a/zzip/__string.h
+++ b/zzip/__string.h
@@ -1,6 +1,8 @@
 #ifndef __ZZIP_INTERNAL_STRING_H
 #define __ZZIP_INTERNAL_STRING_H
 
+#include <stdlib.h>
+
 #ifdef __linux__
 #define _GNU_SOURCE _glibc_developers_are_idiots_to_call_strndup_gnu_specific_
 #endif
@@ -11,6 +13,19 @@
 #include <string.h>
 #elif defined ZZIP_HAVE_STRINGS_H
 #include <strings.h>
+#endif
+
+#if defined ZZIP_HAVE_STRNLEN || defined strnlen
+#define _zzip_strnlen strnlen
+#else
+
+/* if your system does not have strnlen: */
+zzip__new__ size_t
+_zzip_strnlen(const char *p, size_t maxlen)
+{
+    const char * stop = (char *)memchr(p, '\0', maxlen);
+    return stop ? stop - p : maxlen;
+}
 #endif
 
 
@@ -27,7 +42,7 @@ _zzip_strndup(char const *p, size_t maxlen)
        return p;
     } else 
     {
-        size_t len = strnlen(p, maxlen);
+        size_t len = _zzip_strnlen(p, maxlen);
         char* r = malloc(len + 1);
         if (r == NULL)
             return NULL; /* errno = ENOMEM */


### PR DESCRIPTION
The strnlen function is only defined in POSIX.1-2008.
It is missing on Solaris 10 or Mac OS X 10.6 for example.