### PR TITLE
Fix (part of) broken 'make check' on msys2

### DIFF
--- a/README
+++ b/README
@@ -19,12 +19,12 @@ COPYING
 
 LICENSING
   If you can not use a dynalinked library according to LGPL rules,
-  then look at docs/copying.htm for a few hints. Generally the LGPL 
+  then look at docs/copying.htm for a few hints. Generally the LGPL
   has a way for staticlinking as well as the MPL has a way. Anyway,
   special (paid) licenses can be negotiated with the copyright holder.
 
 HOMEPAGE
-  The zziplib project has moved to GitHub where you can find the 
+  The zziplib project has moved to GitHub where you can find the
   last release tags now => https://github.com/gdraheim/zziplib
   The zziplib project was originally hosted at SourceForge with
   the documentation at http://zziplib.sf.net - this is a bit
@@ -42,7 +42,7 @@ INSTALLATION
 
 MAINTENANCE
   The zziplib library is intentionally a lightweight interface to
-  zip files. The author take patches but please consider to put 
+  zip files. The author take patches but please consider to put
   complex extensions into separate modules rather than implanting them
   right into the core of the library engine. All Patches and Bug Reports
   should be sent to Guido Draheim <guidod@gmx.de>.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -56,7 +56,7 @@ check-readme : $(zzcat)  test.zip
 	test -s test.zip || cp $(srcdir)/test.zip test.zip
 	@ echo :$@: checking $(zzcat) test/README 
 	@ $(zzcat) $(srcdir)/README >test.out
-	@ if diff test.out $(README) >$(NULL) \
+	@ if diff --strip-trailing-cr test.out $(README) >$(NULL) \
 	; then rm test.out ; echo check OK ; true \
 	; else rm test.out ; echo check FAIL ; false ; fi
 
@@ -82,8 +82,8 @@ check-sfx : zzshowme$(EXEEXT)
 	echo :$@: "./zzshowme readme >readme.out 2>readme.err" 
 	export LD_LIBRARY_PATH="../zzip/.libs:$$LD_LIBRARY_PATH" \
 	; ./zzshowme readme >readme.out 2>readme.err ; true
-	@ echo 'diff readme.out $(README) || grep "libzzip-" readme.err' \
-	; if test -s readme.out ; then diff readme.out $(README) \
+	@ echo 'diff --strip-trailing-cr readme.out $(README) || grep "libzzip-" readme.err' \
+	; if test -s readme.out ; then diff --strip-trailing-cr readme.out $(README) \
         ; else grep "libzzip-" readme.err || echo "readme.out is empty!" ; fi
 	rm readme.out readme.err
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -55,7 +55,7 @@ check-readme : $(zzcat)  test.zip
 	@ test -f test.zip || $(MAKE) test0.zip 
 	test -s test.zip || cp $(srcdir)/test.zip test.zip
 	@ echo :$@: checking $(zzcat) test/README 
-	@ $(zzcat) test/README >test.out
+	@ $(zzcat) $(srcdir)/README >test.out
 	@ if diff test.out $(README) >$(NULL) \
 	; then rm test.out ; echo check OK ; true \
 	; else rm test.out ; echo check FAIL ; false ; fi

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -704,7 +704,7 @@ check-readme : $(zzcat)  test.zip
 	test -s test.zip || cp $(srcdir)/test.zip test.zip
 	@ echo :$@: checking $(zzcat) test/README 
 	@ $(zzcat) $(srcdir)/README >test.out
-	@ if diff test.out $(README) >$(NULL) \
+	@ if diff --strip-trailing-cr test.out $(README) >$(NULL) \
 	; then rm test.out ; echo check OK ; true \
 	; else rm test.out ; echo check FAIL ; false ; fi
 
@@ -723,8 +723,8 @@ check-sfx : zzshowme$(EXEEXT)
 	echo :$@: "./zzshowme readme >readme.out 2>readme.err" 
 	export LD_LIBRARY_PATH="../zzip/.libs:$$LD_LIBRARY_PATH" \
 	; ./zzshowme readme >readme.out 2>readme.err ; true
-	@ echo 'diff readme.out $(README) || grep "libzzip-" readme.err' \
-	; if test -s readme.out ; then diff readme.out $(README) \
+	@ echo 'diff --strip-trailing-cr readme.out $(README) || grep "libzzip-" readme.err' \
+	; if test -s readme.out ; then diff --strip-trailing-cr readme.out $(README) \
         ; else grep "libzzip-" readme.err || echo "readme.out is empty!" ; fi
 	rm readme.out readme.err
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -703,7 +703,7 @@ check-readme : $(zzcat)  test.zip
 	@ test -f test.zip || $(MAKE) test0.zip 
 	test -s test.zip || cp $(srcdir)/test.zip test.zip
 	@ echo :$@: checking $(zzcat) test/README 
-	@ $(zzcat) test/README >test.out
+	@ $(zzcat) $(srcdir)/README >test.out
 	@ if diff test.out $(README) >$(NULL) \
 	; then rm test.out ; echo check OK ; true \
 	; else rm test.out ; echo check FAIL ; false ; fi

--- a/test/README
+++ b/test/README
@@ -19,16 +19,17 @@ COPYING
 
 LICENSING
   If you can not use a dynalinked library according to LGPL rules,
-  then look at docs/copying.htm for a few hints. Generally the LGPL 
+  then look at docs/copying.htm for a few hints. Generally the LGPL
   has a way for staticlinking as well as the MPL has a way. Anyway,
   special (paid) licenses can be negotiated with the copyright holder.
 
 HOMEPAGE
-  The zziplib project is hosted at SourceForge, the complete
-  documentation can be found at http://zziplib.sf.net - the
-  SourceForge servers are also used to distribute the sources
-  of the zziplib project. Releases are announced via the
-  freshmeat services on http://freshmeat.net/projects/zziplib
+  The zziplib project has moved to GitHub where you can find the
+  last release tags now => https://github.com/gdraheim/zziplib
+  The zziplib project was originally hosted at SourceForge with
+  the documentation at http://zziplib.sf.net - this is a bit
+  outdated but the API has not changed much since then. To get
+  the latest release announcements, watch the GitHub project.
 
 INSTALLATION
   The zziplib sources are built with gnu autotools and they should
@@ -41,7 +42,7 @@ INSTALLATION
 
 MAINTENANCE
   The zziplib library is intentionally a lightweight interface to
-  zip files. The author take patches but please consider to put 
+  zip files. The author take patches but please consider to put
   complex extensions into separate modules rather than implanting them
   right into the core of the library engine. All Patches and Bug Reports
   should be sent to Guido Draheim <guidod@gmx.de>.


### PR DESCRIPTION
This PR consists of three patches
* `test/README` is not found when doing out-of-source build (sounds like a problem on all other platforms as well).
* `diff test.out $(README)` generates noise for two reasons:
  * `zzcat.exe >test.out` has CRLF line endings, but `$(README)` uses plain LF ones
  * `test/README` and `README` were simply different (I guess this should better be handled by reading and comparing to the same file rather than keeping a separate copy which is calling for troubles anyway)

Please note that the wrong file name creates a segfault which is probably an unrelated bug to be handled separately.
```
# test/README does not exist
$ ../bins/zzcat.exe test/README
Segmentation fault
```