### PR TITLE
__zzip_parse_root_directory: Check if rootsize is non-0 and rootseek

### DIFF
--- a/docs/zziplib.html
+++ b/docs/zziplib.html
@@ -415,7 +415,8 @@ generated 2003-12-12
  <code>(<nobr>int fd</nobr>,
 <nobr>struct zzip_disk_trailer * trailer</nobr>,
 <nobr>struct zzip_dir_hdr ** hdr_return</nobr>,
-<nobr>zzip_plugin_io_t io</nobr>)</code>
+<nobr>zzip_plugin_io_t io</nobr>,
+<nobr>zzip_off_t filesize</nobr>)</code>
 
 </td></tr><tr valign="top">
 <td valign="top"><code>ZZIP_DIR*
@@ -1091,7 +1092,8 @@ generated 2003-12-12
  <code>(<nobr>int fd</nobr>,
 <nobr>struct zzip_disk_trailer * trailer</nobr>,
 <nobr>struct zzip_dir_hdr ** hdr_return</nobr>,
-<nobr>zzip_plugin_io_t io</nobr>)</code>
+<nobr>zzip_plugin_io_t io</nobr>,
+<nobr>zzip_off_t filesize</nobr>)</code>
 
 </code></code><dt>
 <dd><p> &nbsp;(../zzip/zip.c)


### PR DESCRIPTION
 __zzip_parse_root_directory: Check if rootsize is non-0 and rootseek lies within the archive. Fixes CVE-2018-7726 and issue/41