### PR TITLE
Fix _zzip_strndup if strndup is not available

### DIFF
--- a/zzip/__string.h
+++ b/zzip/__string.h
@@ -31,6 +31,7 @@ _zzip_strnlen(const char *p, size_t maxlen)
 #if defined ZZIP_HAVE_STRNDUP || defined strndup
 #define _zzip_strndup strndup
 #else
+#include <stdlib.h>
 
 /* if your system does not have strndup: */
 zzip__new__ static char *
@@ -42,7 +43,7 @@ _zzip_strndup(char const *p, size_t maxlen)
     } else 
     {
         size_t len = _zzip_strnlen(p, maxlen);
-        char* r = malloc(len + 1);
+        char* r = (char *)malloc(len + 1);
         if (r == NULL)
             return NULL; /* errno = ENOMEM */
         r[len] = '\0';


### PR DESCRIPTION
If `strn_dup` is not available on the compiling system, a custom version is compiled into `zziplib`. This version uses `malloc`, but there is no include of `stdlib.h` since e78b8d3077ce16e5433020f6098b5120c27ae3e9 moved the include into the `ifdef` of `strnlen`.

This enables compiling under MinGW for instance.