### PR TITLE
One more free() to avoid memory leak.

### DIFF
--- a/zzip/zip.c
+++ b/zzip/zip.c
@@ -589,6 +589,8 @@ __zzip_parse_root_directory(int fd,
 	    free(hdr0);
 	}
     }                           /* else zero (sane) entries */
+    else
+        free(hdr0);
 #  ifndef ZZIP_ALLOW_MODULO_ENTRIES
     return (entries != zz_entries) ? ZZIP_CORRUPTED : 0;
 #  else


### PR DESCRIPTION
When __zzip_parse_root_directory() does not assign hdr0 to *hdr_return because p_reclen is NULL, hdr0 must be free'd locally.