### PR TITLE
docs: convert exception statements to Python 3 compatible

### DIFF
--- a/docs/make-doc.py
+++ b/docs/make-doc.py
@@ -215,7 +215,7 @@ def scan_options (options, list):
         #else
         try:
             input = open(name, "r")
-        except IOError, error:
+        except IOError as error:
             warn(#...... (scan_options) ...............
                 "can not open input file: "+name, error)
             continue
@@ -524,7 +524,7 @@ html.add_page_list(html_pages)
 # and finally print the html-formatted output
 try:
     F = open(o.libhtmlfile, "w")
-except IOError, error:
+except IOError as error:
     warn(# ............. open(o.libhtmlfile, "w") ..............
         "can not open html output file: "+o.libhtmlfile, error)
 else:
@@ -987,7 +987,7 @@ doctype += '"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">'+"\n"
 
 try:
     F = open(o.docbookfile,"w")
-except IOError, error:
+except IOError as error:
     warn("can not open docbook output file: "+o.docbookfile, error)
 else:
     print >> F, doctype, '<reference><title>Manual Pages</title>'
@@ -1009,7 +1009,7 @@ else:
 # _____________________________________________________________________
 try:
     F = open( o.dumpdocfile, "w")
-except IOError, error:
+except IOError as error:
     warn ("can not open"+o.dumpdocfile,error)
 else:
     for func in function_list:

--- a/docs/zzipdoc/commentmarkup.py
+++ b/docs/zzipdoc/commentmarkup.py
@@ -31,7 +31,7 @@ class CommentMarkup:
         comment = self.header.comment
         try:
             comment = self.header.get_otherlines()
-        except Exception, e:
+        except Exception as e:
             pass
         mode = ""
         text = ""

--- a/docs/zzipdoc/docbookdocument.py
+++ b/docs/zzipdoc/docbookdocument.py
@@ -23,14 +23,14 @@ class DocbookDocument:
     def get_title(self):
         if self.title: return title
         try:   return self.text[0].get_title()
-        except Exception, e: pass
+        except Exception as e: pass
         return self.title
     def _xml_doctype(self, rootnode):
         return "<!DOCTYPE "+rootnode+self.docbook_dtd+">"
     def _xml_text(self, xml):
         """ accepts adapter objects with .xml_text() """
         try:   return xml.xml_text()
-        except Exception, e: print "DocbookDocument/text", e; pass
+        except Exception as e: print "DocbookDocument/text", e; pass
         return str(xml)
     def _fetch_rootnode(self, text):
         fetch = Match(r"^[^<>]*<(\w+)\b")
@@ -62,7 +62,7 @@ class DocbookDocument:
             print >>fd, xml_text
             fd.close()
             return True
-        except IOError, e:
+        except IOError as e:
             print "could not open '"+filename+"'file", e
             return False
     def save_all(self, filename):
@@ -90,6 +90,6 @@ class DocbookDocument:
             print >>fd, "</"+self.rootnode+">"
             fd.close()
             return True
-        except IOError, e:
+        except IOError as e:
             print "could not open '"+filename+"'file", e
             return False

--- a/docs/zzipdoc/functionlisthtmlpage.py
+++ b/docs/zzipdoc/functionlisthtmlpage.py
@@ -43,7 +43,7 @@ class FunctionListHtmlPage:
             callspec = entry.head_get_callspec()
             head_text = ("<code><b><function>"+namespec+"</function></b>"
                          +callspec+" : "+prespec+"</code>")
-        except Exception, e:
+        except Exception as e:
             pass
         try:
             extraline = ""
@@ -56,7 +56,7 @@ class FunctionListHtmlPage:
                              '<em><small>'+filename+'</small></em>'+
                              '</td></table>')
             body_text = extraline + body_text
-        except Exception, e:
+        except Exception as e:
             pass
         def link(text):
             return (text & Match("<function>(\w*)</function>")

--- a/docs/zzipdoc/htm2dbk.py
+++ b/docs/zzipdoc/htm2dbk.py
@@ -146,7 +146,7 @@ def htm2dbk_files(args):
             doc.filename = filename
             doc.add(f.read())
             f.close()
-        except IOError, e:
+        except IOError as e:
             print >> sys.stderr, "can not open "+filename
     return doc.value()
 

--- a/docs/zzipdoc/htmldocument.py
+++ b/docs/zzipdoc/htmldocument.py
@@ -29,31 +29,31 @@ class HtmlDocument:
     def get_title(self):
         if self.title: return self.title
         try:   return self.text[0].get_title()
-        except Exception, e: pass
+        except Exception as e: pass
         return self.title
     def _html_meta(self, meta):
         """ accepts adapter objects with .html_meta() """
         try:   return meta.html_meta()
-        except Exception, e: pass
+        except Exception as e: pass
         return str(meta)
     def _html_style(self, style):
         """ accepts adapter objects with .html_style() and .xml_style() """
         ee = None
         try:   return style.html_style()
-        except Exception, e: ee = e; pass
+        except Exception as e: ee = e; pass
         try:   return style.xml_style()
-        except Exception, e: print "HtmlDocument/style", ee, e; pass
+        except Exception as e: print "HtmlDocument/style", ee, e; pass
         try:   return str(style)
-        except Exception, e: print "HtmlDocument/style", e; return ""
+        except Exception as e: print "HtmlDocument/style", e; return ""
     def _html_text(self, html):
         """ accepts adapter objects with .html_text() and .xml_text() """
         ee = None
         try:   return html.html_text()
-        except Exception, e: ee = e; pass
+        except Exception as e: ee = e; pass
         try:   return html.xml_text()
-        except Exception, e: print "HtmlDocument/text", ee, e; pass
+        except Exception as e: print "HtmlDocument/text", ee, e; pass
         try:   return str(html)
-        except Exception, e: print "HtmlDocument/text", e; return "&nbsp;"
+        except Exception as e: print "HtmlDocument/text", e; return "&nbsp;"
     def navigation(self):
         if self.navi:
             return self.navi
@@ -63,7 +63,7 @@ class HtmlDocument:
                 self.navi = fd.read()
                 fd.close()
                 return self.navi
-            except Exception, e:
+            except Exception as e:
                 pass
         return None
     def html_header(self):
@@ -112,6 +112,6 @@ class HtmlDocument:
             print >>fd, self.html_footer()
             fd.close()
             return True
-        except IOError, e:
+        except IOError as e:
             print "could not open '"+filename+"'file", e
             return False

--- a/docs/zzipdoc/textfile.py
+++ b/docs/zzipdoc/textfile.py
@@ -17,7 +17,7 @@ class TextFile:
             self.src_text = fd.read()
             fd.close()
             return True
-        except IOError, e:
+        except IOError as e:
             pass
         return False
     def assert_src_text(self):


### PR DESCRIPTION
Python3 removed support for the except Exception, e syntax this is
supported since Python 2.6