### PR TITLE
Prevent division by zero

### DIFF
--- a/bins/unzip-mem.c
+++ b/bins/unzip-mem.c
@@ -231,9 +231,12 @@ static void zzip_mem_entry_direntry(ZZIP_MEM_ENTRY* entry)
     if (*name == '\n') name++;
 
     if (option_verbose) {
+	long percentage;
+
+	percentage = usize ? (L (100 - (csize*100/usize))) : 100;	/* 100% if file size is 0 */
 	printf("%8li%c %s %8li%c%3li%%  %s  %8lx  %s %s\n", 
 	       L usize, exp, comprlevel[compr], L csize, exp, 
-	       L (100 - (csize*100/usize)),
+	       percentage,
 	       _zzip_ctime(&mtime), crc32, name, comment);
     } else {
 	printf(" %8li%c %s   %s %s\n", 


### PR DESCRIPTION
When verbously listing a ZIP file with directories, a "Floating point exception" occurs because the uncompressed size "usize" is 0. The fix is to print 100% whenever csize and usize are identical, which they are in case of a directory. This may also prevent spurious rounding problems.
Reproducer:
1) create a zip file from a directory (any)
eg `mkdir Test; cp /etc/passwd Test; zip -r Test Test`
2) list zipfile using unzip-mem -v: `unzip-mem -v Test`
Floating point exception (core dumped)