### PR TITLE
Prevent division by zero

### DIFF
--- a/bins/unzip-mem.c
+++ b/bins/unzip-mem.c
@@ -231,9 +231,12 @@ static void zzip_mem_entry_direntry(ZZIP_MEM_ENTRY* entry)
     if (*name == '\n') name++;
 
     if (option_verbose) {
+	long percentage;
+
+	percentage = usize ? (L (100 - (csize*100/usize))) : 100;	/* 100% if file size is 0 */
 	printf("%8li%c %s %8li%c%3li%%  %s  %8lx  %s %s\n", 
 	       L usize, exp, comprlevel[compr], L csize, exp, 
-	       L (100 - (csize*100/usize)),
+	       percentage,
 	       _zzip_ctime(&mtime), crc32, name, comment);
     } else {
 	printf(" %8li%c %s   %s %s\n", 

--- a/bins/unzip-mem.c
+++ b/bins/unzip-mem.c
@@ -233,7 +233,7 @@ static void zzip_mem_entry_direntry(ZZIP_MEM_ENTRY* entry)
     if (option_verbose) {
 	long percentage;
 
-	percentage = usize ? (L (100 - (csize*100/usize))) : 100;	/* 100% if file size is 0 */
+	percentage = usize ? (L (100 - (csize*100/usize))) : 0;	/* 0% if file size is 0 */
 	printf("%8li%c %s %8li%c%3li%%  %s  %8lx  %s %s\n", 
 	       L usize, exp, comprlevel[compr], L csize, exp, 
 	       percentage,

--- a/test/zziptests.py
+++ b/test/zziptests.py
@@ -3429,6 +3429,26 @@ class ZZipTest(unittest.TestCase):
     self.assertTrue(os.path.exists(workdir+"/test/evil.conf"))
     self.rm_testdir()
 
+  def test_65485_list_verbose_compressed_with_directory(self):
+    """ verbously list a zipfile containing directories """
+    tmpdir = self.testdir()
+    workdir = tmpdir + "/d"
+    zipname = "ZIPfile"
+    os.makedirs(workdir)
+    f= open(tmpdir + "/d/file","w+")
+    for i in range(10):
+      f.write("This is line %d\r\n" % (i+1))
+    f.close()
+    # create the ZIPfile
+    exe=self.bins("zzip")
+    run = shell("chdir {tmpdir} && ../{exe} -9 {zipname}.zip d".format(**locals()))
+    self.assertFalse(run.returncode)
+    # list the ZIPfile
+    exe=self.bins("unzip-mem");
+    run = shell("chdir {tmpdir} && ../{exe} -v {zipname}.zip".format(**locals()))
+    self.assertFalse(run.returncode)
+    self.rm_testdir()
+
   def test_91000_zzshowme_check_sfx(self):
     """ create an *.exe that can extract its own zip content """
     exe=self.bins("mkzip")


### PR DESCRIPTION
When verbously listing a ZIP file with directories, a "Floating point exception" occurs because the uncompressed size "usize" is 0. The fix is to print 0% when usize is 0.
Reproducer:
mkdir d; for i in $(seq 1 10); do echo This is line $i; done > d/file.txt
zip -9r ZIPfile.zip d
unzip-mem -v ZIPfile.zip
Floating point exception