### PR TITLE
Fixes to various compiler warnings

### DIFF
--- a/zzip/__string.h
+++ b/zzip/__string.h
@@ -23,7 +23,7 @@ static size_t
 _zzip_strnlen(const char *p, size_t maxlen)
 {
     const char * stop = (char *)memchr(p, '\0', maxlen);
-    return stop ? stop - p : maxlen;
+    return stop ? (size_t)(stop - p) : maxlen;
 }
 #endif
 

--- a/zzip/__string.h
+++ b/zzip/__string.h
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 
 /* if your system does not have strnlen: */
-zzip__new__ static size_t
+static size_t
 _zzip_strnlen(const char *p, size_t maxlen)
 {
     const char * stop = (char *)memchr(p, '\0', maxlen);

--- a/zzip/format.h
+++ b/zzip/format.h
@@ -71,7 +71,7 @@ struct zzip_file_header
     /* followed by filename (of variable size) */
     /* followed by extra field (of variable size) */
 } ZZIP_GNUC_PACKED;
-#define zzip_file_header_headerlength (4+2+2+2+4+4+4+4+2+2)
+#define zzip_file_header_headerlength (4U+2U+2U+2U+4U+4U+4U+4U+2U+2U)
 
 /* B. data descriptor
  * the data descriptor exists only if bit 3 of z_flags is set. It is byte aligned
@@ -87,7 +87,7 @@ struct zzip_file_trailer
     zzip_byte_t   z_csize[4]; /* compressed size */
     zzip_byte_t   z_usize[4]; /* uncompressed size */
 } ZZIP_GNUC_PACKED;
-#define zzip_file_trailer_headerlength (4+4+4+4)
+#define zzip_file_trailer_headerlength (4U+4U+4U+4U)
 
 /* C. central directory structure:
     [file header] . . . end of central dir record
@@ -121,7 +121,7 @@ struct zzip_disk_entry
     /* followed by extra field (of variable size) */
     /* followed by file comment (of variable size) */
 } ZZIP_GNUC_PACKED;
-#define zzip_disk_entry_headerlength (4+2+2+2+2+4+4+4+4+2+2+2+2+2+4+4)
+#define zzip_disk_entry_headerlength (4U+2U+2U+2U+2U+4U+4U+4U+4U+2U+2U+2U+2U+2U+4U+4U)
 
 
 struct zzip_root_dirent
@@ -163,7 +163,7 @@ struct zzip_disk_trailer
     zzip_byte_t  z_comment[2];  /* zipfile comment length */
     /* followed by zipfile comment (of variable size) */
 } ZZIP_GNUC_PACKED;
-#define zzip_disk_trailer_headerlength (4+2+2+2+2+4+4+2)
+#define zzip_disk_trailer_headerlength (4U+2U+2U+2U+2U+4U+4U+2U)
 
 /* extra field should be type + size + data + type + size + data ... */
 struct zzip_extra_block
@@ -171,7 +171,7 @@ struct zzip_extra_block
     zzip_byte_t  z_datatype[2];       /* as input type - a mere <char*> is okay */
     zzip_byte_t  z_datasize[2];       /* being returned by xx_to_extras usually */
 } ZZIP_GNUC_PACKED;
-#define zzip_extra_block_headerlength (2+2)
+#define zzip_extra_block_headerlength (2U+2U)
 
 /* Zip64 end of central dir record */
 struct zzip_disk64_trailer
@@ -191,7 +191,7 @@ struct zzip_disk64_trailer
                           * the starting disk number */
     /* followed by zip64 extensible data sector (of variable size) */
 } ZZIP_GNUC_PACKED;
-#define zzip_disk64_trailer_headerlength (4+8+2+2+4+4+8+8+8+8)
+#define zzip_disk64_trailer_headerlength (4U+8U+2U+2U+4U+4U+8U+8U+8U+8U)
 
 /* z_flags */
 #define ZZIP_IS_ENCRYPTED(p)    ((*(zzip_byte_t*)p)&1)

--- a/zzip/fseeko.c
+++ b/zzip/fseeko.c
@@ -76,7 +76,9 @@
 
 /* we try to round all seeks to the pagesize - since we do not use
  * the sys/mmap interface we have to guess a good value here: */
-#define PAGESIZE 8192
+#ifndef PAGESIZE
+# define PAGESIZE 8192
+#endif
 
 #ifdef DEBUG
 #define debug1(msg) do { fprintf(stderr, "DEBUG: %s : " msg "\n", __func__); } while(0)

--- a/zzip/fseeko.c
+++ b/zzip/fseeko.c
@@ -712,7 +712,7 @@ zzip_entry_fopen(ZZIP_ENTRY * entry, int takeover)
     file->zlib.zalloc = Z_NULL;
     file->zlib.zfree = Z_NULL;
 
-    ___ zzip_off_t size = file->avail;
+    ___ zzip_size_t size = file->avail;
     if (size > sizeof(file->buffer))
         size = sizeof(file->buffer);
     if (fseeko(file->entry->diskfile, file->data + file->dataoff, SEEK_SET) == -1)

--- a/zzip/fseeko.c
+++ b/zzip/fseeko.c
@@ -387,7 +387,7 @@ zzip_entry_findfirst(FILE * disk)
                     errno = EFBIG;
                     goto error2;
                 }
-                if ((void*)(trailer + 1) > (buffer + mapsize))
+                if ((p + sizeof(*trailer)) > (buffer + mapsize))
                 {
                     debug1("disk64 trailer is not complete");
                     errno = EBADMSG;

--- a/zzip/info.c
+++ b/zzip/info.c
@@ -70,7 +70,7 @@ static const char* comprlevel[] = {
 zzip_char_t *
 zzip_compr_str(int compr)
 {
-    if (0 <= compr && compr < LENGTH(comprlevel))
+    if (0 <= compr && (unsigned) compr < LENGTH(comprlevel))
     {
         return comprlevel[compr];
     } else if (0 < compr && compr < 256) 

--- a/zzip/memdisk.c
+++ b/zzip/memdisk.c
@@ -114,7 +114,7 @@ zzip_mem_disk_fdopen(int fd)
     ___ ZZIP_MEM_DISK *dir = zzip_mem_disk_new();
     if (zzip_mem_disk_load(dir, disk) == -1)
     {
-       debug2("unable to load disk fd %s", fd);
+       debug2("unable to load disk fd %i", fd);
     }
     return dir;
     ____;

--- a/zzip/memdisk.c
+++ b/zzip/memdisk.c
@@ -244,10 +244,10 @@ zzip_mem_entry_new(ZZIP_DISK * disk, ZZIP_DISK_ENTRY * entry)
     }
 
     {   /* copy the extra blocks to memory as well (maximum 64K each) */
-        zzip_size_t /*    */ ext1_len = zzip_disk_entry_get_extras(entry);
-        char *_zzip_restrict ext1_ptr = zzip_disk_entry_to_extras(entry);
-        zzip_size_t /*    */ ext2_len = zzip_file_header_get_extras(header);
-        char *_zzip_restrict ext2_ptr = zzip_file_header_to_extras(header);
+        zzip_size_t /*           */ ext1_len = zzip_disk_entry_get_extras(entry);
+        zzip_byte_t *_zzip_restrict ext1_ptr = zzip_disk_entry_to_extras(entry);
+        zzip_size_t /*           */ ext2_len = zzip_file_header_get_extras(header);
+        zzip_byte_t *_zzip_restrict ext2_ptr = zzip_file_header_to_extras(header);
 
         if (ext1_len > 0 && ext1_len <= 65535)
         {


### PR DESCRIPTION
It really is mostly uninteresting fixes, most of them caused by CMake including "-Wsign-compare". I guess it's good to have them anyway to enable for clean builds with "-Werror". More info is in the commit messages, just in case the fix is debatable.