### PR TITLE
CMake fixes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,6 @@ add_custom_command(OUTPUT test0.zip
     COMMAND ${CP} ${README} tmp/README
     COMMAND ${BASH} -c "cd tmp && ${MKZIP} ../test0.zip README"
     COMMAND ${CP} test0.zip test.zip
-    COMMAND ${CP} test0.zip ${srcdir}/test.zip
     BYPRODUCTS test.zip
     VERBATIM)
 add_custom_target(testzips ALL DEPENDS test0.zip)


### PR DESCRIPTION
Some fixes to CMake that I found while experimenting with Travis CI. My systems have zziplib installed, but Travis doesn't, which is how I found the include errors. I'll propose a Travis CI setup as soon as this PR is merged.

More details in the commit messages.