### PR TITLE
zzipdoc: convert use of print statement

### DIFF
--- a/docs/zzipdoc/docbookdocument.py
+++ b/docs/zzipdoc/docbookdocument.py
@@ -33,7 +33,7 @@ class DocbookDocument:
     def _xml_text(self, xml):
         """ accepts adapter objects with .xml_text() """
         try:   return xml.xml_text()
-        except Exception as e: print "DocbookDocument/text", e; pass
+        except Exception as e: print("DocbookDocument/text " + e); pass
         return str(xml)
     def _fetch_rootnode(self, text):
         fetch = Match(r"^[^<>]*<(\w+)\b")


### PR DESCRIPTION
Commit 5b660a3 (Merge pull request #72 from jelly/python3, 2019-08-04)
introduced a conversion to use new-style Python exceptions.
The conversion introduced a new print statements, though, breaking
compatibility with Python 3 again.

Convert the statement to use the print function, instead.