### PR TITLE
zzip/CMakeLists.txt: fix for macOS

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -276,6 +276,10 @@ if(ZZIPCOMPAT)
     get_target_property(libversion libzzip VERSION)
     install(CODE "execute_process(COMMAND bash -c \"set -e
         cd $DESTDIR/${libdir}
+        if [ -f ${lib}${libname}${librelease}.${libversion}${dll} ]; then
+          # Fix for APPLE where dylib goes in the end
+          ln -s ${lib}${libname}${librelease}.${libversion}${dll} ${lib}${libname}${librelease}${dll}.${libversion}
+        fi
         [ -f ${lib}${libname}${librelease}${dll}.${libversion} ] || exit 0
         echo -n .. Installing: `pwd`
         ln -svf ${lib}${libname}${librelease}${dll}.${libversion} ${lib}${libname}${librelease}${dll}
@@ -299,6 +303,10 @@ if(ZZIPLIBTOOL)
     get_target_property(libversion libzzip VERSION)
     install(CODE "execute_process(COMMAND bash -c \"set -e
         cd $DESTDIR/${libdir}
+        if [ -f ${lib}${libname}${librelease}.${libversion}${dll} ]; then
+          # Fix for APPLE where dylib goes in the end
+          ln -s ${lib}${libname}${librelease}.${libversion}${dll} ${lib}${libname}${librelease}${dll}.${libversion}
+        fi
         [ -f ${lib}${libname}${librelease}${dll}.${libversion} ] || exit 0
         echo -n .. Installing: `pwd`
         ln -svf ${lib}${libname}${librelease}${dll}.${libversion} ${lib}${libname}${dll}
@@ -314,6 +322,10 @@ if(ZZIPLIBTOOL)
     get_target_property(libversion libzzipfseeko VERSION)
     install(CODE "execute_process(COMMAND bash -c \"set -e
         cd $DESTDIR/${libdir}
+        if [ -f ${lib}${libname}${librelease}.${libversion}${dll} ]; then
+          # Fix for APPLE where dylib goes in the end
+          ln -s ${lib}${libname}${librelease}.${libversion}${dll} ${lib}${libname}${librelease}${dll}.${libversion}
+        fi
         [ -f ${lib}${libname}${librelease}${dll}.${libversion} ] || exit 0
         echo -n .. Installing: `pwd`
         ln -svf ${lib}${libname}${librelease}${dll}.${libversion} ${lib}${libname}${dll}
@@ -329,6 +341,10 @@ if(ZZIPLIBTOOL)
     get_target_property(libversion libzzipmmapped VERSION)
     install(CODE "execute_process(COMMAND bash -c \"set -e
         cd $DESTDIR/${libdir}
+        if [ -f ${lib}${libname}${librelease}.${libversion}${dll} ]; then
+          # Fix for APPLE where dylib goes in the end
+          ln -s ${lib}${libname}${librelease}.${libversion}${dll} ${lib}${libname}${librelease}${dll}.${libversion}
+        fi
         [ -f ${lib}${libname}${librelease}${dll}.${libversion} ] || exit 0
         echo -n .. Installing: `pwd`
         ln -svf ${lib}${libname}${librelease}${dll}.${libversion} ${lib}${libname}${dll}


### PR DESCRIPTION
We've noticed that on macOS the library symlinks were not creating. Turns out, the condition
https://github.com/gdraheim/zziplib/blob/c3de4fe291ab6756593a0ef6bad007ddd3953e00/zzip/CMakeLists.txt#L302
was silently failing for us. This happens because the names of the libraries are generated differently for apple, we get `libzzip-0.13.0.71.dylib` when the code in zziplib expects `libzzip-0.dylib.13.0.71`.

https://gitlab.kitware.com/cmake/cmake/-/blob/742ff97f809410055b22405a6b5728e72c458683/Source/cmGeneratorTarget.cxx#L5890-5903

Also a related thread:
https://cmake.org/pipermail/cmake/2013-February/053605.html

cc @jtojnar 