### PR TITLE
zzip/__string.h: cast to avoid compiler warning

### DIFF
--- a/zzip/__string.h
+++ b/zzip/__string.h
@@ -39,7 +39,7 @@ _zzip_strndup(char const *p, size_t maxlen)
 {
     if (p == NULL)
     {
-       return p;
+       return (char *)p;
     } else 
     {
         size_t len = _zzip_strnlen(p, maxlen);


### PR DESCRIPTION
This is a tiny patch to avoid compiler warning.

Best regards,
