### PR TITLE
support of MacPort's zip and unzip

### DIFF
--- a/test/zziptests.py
+++ b/test/zziptests.py
@@ -1848,10 +1848,10 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 430)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [2])
+        returncodes = [2,12])
     self.assertLess(len(run.output), 90)
     self.assertLess(len(errors(run.errors)), 900)
-    self.assertIn('file #1:  bad zipfile offset (local header sig):  127', run.errors)
+    self.assertTrue(any(x in run.errors for x in ('file #1:  bad zipfile offset (local header sig):  127', 'error: invalid zip file with overlapped components (possible zip bomb)')))
     #self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -2092,10 +2092,10 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 500)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.assertLess(len(run.output), 90)
     self.assertLess(len(errors(run.errors)), 900)
-    self.assertIn('file #1:  bad zipfile offset (lseek)', run.errors)
+    self.assertTrue(any(x in run.errors for x in ('file #1:  bad zipfile offset (lseek)', 'invalid zip file with overlapped components (possible zip bomb)')))
     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -3189,11 +3189,11 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 800)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.assertLess(len(run.output), 200)
     self.assertLess(len(errors(run.errors)), 800)
     self.assertIn("missing 18 bytes in zipfile", run.errors)
-    self.assertIn('expected central file header signature not found', run.errors)
+    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -3232,13 +3232,13 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 800)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.assertGreater(len(run.output), 30)
     self.assertGreater(len(errors(run.errors)), 1)
     self.assertLess(len(run.output), 400)
     self.assertLess(len(errors(run.errors)), 800)
     self.assertIn("missing 18 bytes in zipfile", run.errors)
-    self.assertIn('expected central file header signature not found', run.errors)
+    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -3456,11 +3456,11 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 800)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.assertLess(len(run.output), 400)
     self.assertLess(len(errors(run.errors)), 800)
     self.assertIn("missing 5123 bytes in zipfile", run.errors)
-    self.assertIn("expected central file header signature not found", run.errors)
+    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -3583,13 +3583,13 @@ class ZZipTest(unittest.TestCase):
     self.assertLess(len(errors(run.errors)), 800)
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.assertGreater(len(run.output), 20)
     self.assertGreater(len(errors(run.errors)), 1)
     self.assertLess(len(run.output), 2500)
     self.assertLess(len(errors(run.errors)), 800)
     self.assertIn("missing 21 bytes in zipfile", run.errors)
-    self.assertIn('expected central file header signature not found', run.errors)
+    self.assertTrue(any(x in run.errors for x in ('expected central file header signature not found', 'invalid zip file with overlapped components (possible zip bomb)')))
     # self.assertEqual(os.path.getsize(tmpdir+"/test"), 3)
     self.assertFalse(os.path.exists(tmpdir+"/test"))
     self.rm_testdir()
@@ -3792,7 +3792,7 @@ class ZZipTest(unittest.TestCase):
     self.assertTrue(greps(run.errors, "missing 6 bytes in zipfile"))
     #
     run = shell("cd {tmpdir} && {exe} -o {filename}".format(**locals()),
-        returncodes = [3])
+        returncodes = [3,12])
     self.rm_testdir()
   def test_65671(self):
     """ unzzip-big -l $(CVE).zip  """


### PR DESCRIPTION
MacPorts ships different version of `unzip` and `zip`. This small pull request adjusts tests to supporting them.

Closes https://github.com/gdraheim/zziplib/issues/123