### PR TITLE
CMakeLists.txt: enable ZZIP_LIBLATEST only in Release mode

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -28,7 +28,7 @@ option(ZZIP_LIBTOOL "Ensure binary compatibility with libtool" OFF)
 option(ZZIP_PKGCONFIG "Generate pkg-config files for linking" OFF)
 endif()
 
-if(ZZIP_LIBTOOL OR ZZIP_PKGCONFIG)
+if((CMAKE_BUILD_TYPE STREQUAL "Release") AND (ZZIP_LIBTOOL OR ZZIP_PKGCONFIG))
 option(ZZIP_LIBLATEST "Ensure libname.lib links to libname-REL.lib" ON)
 else()
 option(ZZIP_LIBLATEST "Ensure libname.lib links to libname-REL.lib" OFF)

--- a/zzipwrap/CMakeLists.txt
+++ b/zzipwrap/CMakeLists.txt
@@ -21,7 +21,7 @@ option(ZZIP_LIBTOOL "Ensure binary compatibility with libtool" OFF)
 option(ZZIP_PKGCONFIG "Generate pkg-config files for linking" OFF)
 endif()
 
-if(ZZIP_LIBTOOL OR ZZIP_PKGCONFIG)
+if((CMAKE_BUILD_TYPE STREQUAL "Release") AND (ZZIP_LIBTOOL OR ZZIP_PKGCONFIG))
 option(ZZIP_LIBLATEST "Ensure libname.lib links to libname-REL.lib" ON)
 else()
 option(ZZIP_LIBLATEST "Ensure libname.lib links to libname-REL.lib" OFF)


### PR DESCRIPTION
Enable `ZZIP_LIBLATEST` only in Release mode to avoid the following build failure raised since commit 0e8d35f92efb680c81f6ec1fca9f11d173dce389 and c835ad662a91b3df041a2144e11f932cfa4f98b4 because `RELEASE_POSTFIX` will be empty if `CMAKE_BUILD_TYPE` is set to `Debug` resulting in the symlinks overriding the libraries:

```
make[3]: stat: zzip/libzzipfseeko.a: Too many levels of symbolic links
make[3]: *** No rule to make target 'zzip/libzzipfseeko.a', needed by 'bins/unzzip-big'.  Stop.
```

Fixes:
 - http://autobuild.buildroot.org/results/9cd4147486f32d642513ba14efca3a02d5745ab9

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>