### PR TITLE
[cmake] Export targets

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -180,7 +180,7 @@ set(libzzipmmapped_HDRS mmapped.h memdisk.h)
 
 add_library(libzzip ${libzzip_SRCS} )
 target_link_libraries(libzzip ZLIB::ZLIB )
-target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC $<INSTALL_INTERFACE:include/zzip>)
 
 if(ZZIPFSEEKO)
 add_library(libzzipfseeko ${libzzipfseeko_SRCS} )
@@ -260,14 +260,14 @@ install(FILES ${outdir}/zziplib.pc ${outdir}/zzipmmapped.pc ${outdir}/zzipfseeko
 endif()
 
 install(FILES ${libzzip_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
-install(TARGETS libzzip 
+install(TARGETS libzzip EXPORT zziplibTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 if(ZZIPFSEEKO)
 install(FILES ${libzzipfseeko_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
-install(TARGETS libzzipfseeko 
+install(TARGETS libzzipfseeko EXPORT zziplibTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -275,11 +275,27 @@ endif()
 
 if(ZZIPMMAPPED)
 install(FILES ${libzzipmmapped_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
-install(TARGETS libzzipmmapped
+install(TARGETS libzzipmmapped EXPORT zziplibTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
+
+install(EXPORT zziplibTargets
+    NAMESPACE zziplib::
+    DESTINATION share/zziplib
+)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/zziplib-config.cmake.in"
+[[include(CMakeFindDependencyMacro)
+find_dependency(ZLIB)
+file(GLOB TARGET_FILES "${CMAKE_CURRENT_LIST_DIR}/*Targets.cmake")
+foreach (TARGET_FILE ${TARGET_FILES})
+    include("${TARGET_FILE}")
+endforeach()
+]])
+configure_file("${CMAKE_CURRENT_BINARY_DIR}/zziplib-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/zziplib-config.cmake" @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zziplib-config.cmake DESTINATION share/zziplib)
 
 if(ZZIP_COMPAT OR ZZIP_LIBTOOL)
   if(BUILD_SHARED_LIBS AND CMAKE_SHARED_LIBRARY_SONAME_C_FLAG)

--- a/zzipwrap/CMakeLists.txt
+++ b/zzipwrap/CMakeLists.txt
@@ -88,7 +88,7 @@ install(FILES ${outdir}/zzipwrap.pc
 endif()
 
 install(FILES ${libzzipwrap_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
-install(TARGETS libzzipwrap
+install(TARGETS libzzipwrap EXPORT zziplibTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Export cmake targets so the users can easily use zziplib in cmake.

Fixes #134.