### PR TITLE
zzip/fseeko.h: Fix closing extern C bracket

### DIFF
--- a/zzip/fseeko.h
+++ b/zzip/fseeko.h
@@ -147,7 +147,6 @@ struct zzip_entry /* : struct zzip_disk_entry */
 #endif
 
 #ifdef __cplusplus
-extern "C" {
 }
 #endif
 #endif


### PR DESCRIPTION
Line 24 in `zzip/fseeko.h` opens the `extern "C"` bracket. This bracket needs to be closed at the end of the file.