### PR TITLE
mmappend.c: pre-check header trailer magic

### DIFF
--- a/zzip/mmapped.c
+++ b/zzip/mmapped.c
@@ -283,7 +283,9 @@ zzip_disk_entry_to_file_header(ZZIP_DISK * disk, struct zzip_disk_entry *entry)
         return 0;
     }
     ___  struct zzip_file_header *file_header = (void *) ptr;
-    if (zzip_file_header_get_magic(file_header) != ZZIP_FILE_HEADER_MAGIC)
+    
+    if (file_header != 'P' || /* quick pre-check for trailer magic */
+        zzip_file_header_get_magic(file_header) != ZZIP_FILE_HEADER_MAGIC)
     {
         debug1("file header: bad magic");
         errno = EBADMSG;


### PR DESCRIPTION
* Avoid potential ASAN:SIGSEGV invalid memory access by pre-check the header trailer magic.
Somehow, the pointer could overflow in the buffer especially for 32bits architecture where the value become higher of the maximal value of an uint32_t. Checking the value of the pointer before trying to read the zzip_file_header struct will avoid a potential "invalid memory access".
* CVE-2020-18770 from #69 