### PR TITLE
parse_root_dir: Verify size of extra obtained

### DIFF
--- a/zzip/zip.c
+++ b/zzip/zip.c
@@ -525,7 +525,8 @@ __zzip_parse_root_directory(int fd, struct _disk_trailer* trailer, struct zzip_d
         hdr->d_namlen         = u_namlen;
 
         /* looking for ZIP64 extras when csize on intmax */
-        if (u_extras && (hdr->d_csize & 0xFFFFu == 0xFFFFu)) {
+        if (u_extras >= __sizeof(struct zzip_extra_zip64) &&
+            (hdr->d_csize & 0xFFFFu == 0xFFFFu)) {
             DBG3("%i extras bytes (%i)", u_extras, sizeof(struct zzip_extra_zip64));
             zzip_off64_t zz_extras = zz_offset + sizeof(*d) + u_namlen;
             zzip_byte_t* extras_ptr;


### PR DESCRIPTION
Fix the #164 where extra_ptr could be alocated without enough bytes to check the magic value.

Indeed, ZZIP_EXTRA_ZIP64_CHECK, or later in the code, will call ZZIP_GETEXTRA() where it get 2 first bytes to check the magic number. 
However, there is not any verification about the size allocated for `extras_ptr`, where by the value of `u_extras`, `extras_ptr` could be allocated of 1 byte (what happened with the provided POC in the bug description). We should be sure that `u_extra` allocates the `extras_ptr` with more that 2 bytes, or better, at least same value of the size of the `zzip_extra_zip64` struct.