### PR TITLE
old.configure.ac: fix bashism

### DIFF
--- a/old.configure.ac
+++ b/old.configure.ac
@@ -332,7 +332,7 @@ case "$host_os" in mingw*)
 ;; *)
     if test ".$can_build_shared" != ".no" ; then
       ZZIPLIB_LDFLAGS="-export-dynamic"
-      if test ".$lt_cv_prog_gnu_ld" == ".yes" ; then
+      if test ".$lt_cv_prog_gnu_ld" = ".yes" ; then
          ZZIPLIB_LDFLAGS="${wl}--export-dynamic"
          # TODO: that is for backward compatibility only
       fi


### PR DESCRIPTION
strict posix shells (e.g. dash) reject the "==" operator:

> checking link options... .././configure: 13736: test: .yes: unexpected operator
-export-dynamic  #