### PR TITLE
move zzipwrap's .pc from $libdir to $datadir

### DIFF
--- a/zzipwrap/CMakeLists.txt
+++ b/zzipwrap/CMakeLists.txt
@@ -84,7 +84,7 @@ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
 
 if(ZZIP_PKGCONFIG)
 install(FILES ${outdir}/zzipwrap.pc 
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" )
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
 endif()
 
 install(FILES ${libzzipwrap_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )

--- a/zzipwrap/Makefile.am
+++ b/zzipwrap/Makefile.am
@@ -35,7 +35,7 @@ zzipwrap_LDFLAGS =  @ZZIPLIB_LDFLAGS@
 zzipwrap_LDADD = libzzipwrap.la @RESOLVES@ ../zzip/libzzip.la -lz
 
 # ----------------------------------------------------------------------
-pkgconfigdir=$(libdir)/pkgconfig
+pkgconfigdir=$(datarootdir)/pkgconfig
 pkgconfig_HEADERS= zzipwrap.pc
 
 zzipwrap.pc : Makefile

--- a/zzipwrap/Makefile.in
+++ b/zzipwrap/Makefile.in
@@ -381,7 +381,7 @@ pkgconfig_libdir = @pkgconfig_libdir@
 pkgconfig_libfile = @pkgconfig_libfile@
 
 # ----------------------------------------------------------------------
-pkgconfigdir = $(libdir)/pkgconfig
+pkgconfigdir = $(datarootdir)/pkgconfig
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@


### PR DESCRIPTION
From a previous commit 4b2b33f379e508a41a9e43009db921866955a02f, zzip's .pc files has been moved from $libdir/pkgconfig to $datadir/pkgconfig.


Should we do the same for zzipwrap ?