### PR TITLE
install pkconfig files into libdir rather than datadir

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -304,7 +304,7 @@ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
 
 if(ZZIP_PKGCONFIG)
 install(FILES ${outdir}/zziplib.pc ${outdir}/zzipmmapped.pc ${outdir}/zzipfseeko.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" )
 endif()
 
 install(FILES ${libzzip_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )


### PR DESCRIPTION
`zziplib.pc` `zzipmmapped.pc` `zzipfseeko.pc` actually contain arch-dependent content such as `$libdir`,  they should be put into `$(libdir}/pkgconfig` rather than `${datadir}/pkgconfig`.