### PR TITLE
move zzip/zzipwrap pc files from datadir to libdir

### DIFF
--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -304,7 +304,7 @@ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
 
 if(ZZIP_PKGCONFIG)
 install(FILES ${outdir}/zziplib.pc ${outdir}/zzipmmapped.pc ${outdir}/zzipfseeko.pc
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" )
 endif()
 
 install(FILES ${libzzip_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )

--- a/zzip/Makefile.am
+++ b/zzip/Makefile.am
@@ -156,7 +156,7 @@ i:
 	; cp $(file) $(srcdir)/$$f
 
 # ----------------------------------------------------------------------
-pkgconfigdir=$(datarootdir)/pkgconfig
+pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_HEADERS= zzip-zlib-config.pc zziplib.pc \
                     zzipmmapped.pc zzipfseeko.pc
 

--- a/zzip/Makefile.in
+++ b/zzip/Makefile.in
@@ -387,7 +387,7 @@ pkgconfig_libdir = @pkgconfig_libdir@
 pkgconfig_libfile = @pkgconfig_libfile@
 
 # ----------------------------------------------------------------------
-pkgconfigdir = $(datarootdir)/pkgconfig
+pkgconfigdir = $(libdir)/pkgconfig
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@

--- a/zzipwrap/CMakeLists.txt
+++ b/zzipwrap/CMakeLists.txt
@@ -84,7 +84,7 @@ set(outdir ${CMAKE_CURRENT_BINARY_DIR})
 
 if(ZZIP_PKGCONFIG)
 install(FILES ${outdir}/zzipwrap.pc 
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig" )
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" )
 endif()
 
 install(FILES ${libzzipwrap_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )

--- a/zzipwrap/Makefile.am
+++ b/zzipwrap/Makefile.am
@@ -35,7 +35,7 @@ zzipwrap_LDFLAGS =  @ZZIPLIB_LDFLAGS@
 zzipwrap_LDADD = libzzipwrap.la @RESOLVES@ ../zzip/libzzip.la -lz
 
 # ----------------------------------------------------------------------
-pkgconfigdir=$(datarootdir)/pkgconfig
+pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_HEADERS= zzipwrap.pc
 
 zzipwrap.pc : Makefile

--- a/zzipwrap/Makefile.in
+++ b/zzipwrap/Makefile.in
@@ -381,7 +381,7 @@ pkgconfig_libdir = @pkgconfig_libdir@
 pkgconfig_libfile = @pkgconfig_libfile@
 
 # ----------------------------------------------------------------------
-pkgconfigdir = $(datarootdir)/pkgconfig
+pkgconfigdir = $(libdir)/pkgconfig
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@


### PR DESCRIPTION
* pc files for zzip and zzipwrap contains libdir informations, they should remain in libdir pkgconf dir. #178